### PR TITLE
feat: add full CAIP-2 format support for interop-sdk compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ Thumbs.db
 
 # npm authentication
 .npmrc 
+
+# package-lock.json
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unruggable/ens-7828-resolver",
-  "version": "0.1.0",
+  "version": "0.1.2",
   "type": "module",
   "description": "A fully-featured TypeScript library for parsing, resolving and displaying EIP-7828-style human-readable, chain-specific ENS names",
   "main": "dist/index.js",

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -116,12 +116,27 @@ export function validateENSName(name: string): boolean {
  * @returns An object with namespace and reference fields
  * @example
  * parseCAIP2ChainId("1") // { namespace: "eip155", reference: "1" }
+ * parseCAIP2ChainId("eip155:1") // { namespace: "eip155", reference: "1" }
  * parseCAIP2ChainId("solana") // { namespace: "eip155", reference: "solana" }
  */
 export function parseCAIP2ChainId(chainSpec: string): {
   namespace: string;
   reference: string;
 } {
+  // Handle full CAIP-2 format e.g., eip155:1, bip122:000000000019d6689c085ae165831e93
+  if (chainSpec.includes(":")) {
+    const [namespace, reference] = chainSpec.split(":", 2);
+    if (!namespace || !reference) {
+      throw new Error(
+        "Invalid CAIP-2 format: namespace and reference required"
+      );
+    }
+    return {
+      namespace,
+      reference,
+    };
+  }
+
   // Handle shorthand format e.g vitalik.eth@1
   if (/^\d+$/.test(chainSpec)) {
     return {

--- a/test-resolver.js
+++ b/test-resolver.js
@@ -84,7 +84,7 @@ console.log("");
 // Test 5: Full EIP-7828 Name Parsing
 console.log("EIP-7828 Name Parsing Test:");
 const test7828Names = [
-  "alice.eth@1",
+  "alice.eth@eip155:1",
   "vitalik.eth@ethereum",
   "test.app.eth@base",
   "bob.eth@optimism#abcd1234",
@@ -109,6 +109,7 @@ console.log("");
 console.log("Full Resolution Test:");
 const resolutionTestNames = [
   "premm.eth@1",
+  "nick.eth@eip155:1",
   "ndeto.eth@solana",
   "vitalik.eth@ethereum",
   "clowes.eth@celo",


### PR DESCRIPTION
## Add Full CAIP-2 Format Support for Interop-SDK Compatibility

### **Purpose**
This PR adds support for full CAIP-2 format chain specifications in EIP-7828 names to enable seamless integration with [defi-wonderland/interop-sdk](https://github.com/defi-wonderland/interop-sdk/tree/dev/packages/addresses) and other libraries that use the complete `namespace:reference` format.

### **Changes**
- **Enhanced `parseCAIP2ChainId` function** to handle full CAIP-2 formats like `eip155:1`, `bip122:000000000019d6689c085ae165831e93`

How this flow interplays:

```javascript
// 1. Binary address from interop-sdk addresses package
import { InteropAddressProvider } from '@defi-wonderland/interop-sdk/addresses';
const humanReadableAddress = "ndeto.eth@eip155:1#ABCD1234";
const binaryAddress = InteropAddressProvider.humanReadableToBinary(humanReadableAddress);

// 2. Convert binary back to human-readable using interop-sdk
import { binaryToHumanReadable } from '@defi-wonderland/interop-sdk/addresses';
const humanReadable = binaryToHumanReadable(binaryAddress);
// Result: "ndeto.eth@eip155:1#ABCD1234"

// 3. Resolve the human-readable format using our ens-7828-resolver
import { resolve7828 } from '@unruggable/ens-7828-resolver';
const resolved = await resolve7828(humanReadable);
// resolved.address === "0x49D9Dc4233457CBC08Bb4830786Df5dd9e02dFa5"
// resolved.caip10 === "eip155:1:0x49D9Dc4233457CBC08Bb4830786Df5dd9e02dFa5"
```

### **Breaking Changes**
None